### PR TITLE
Add pingBackend to spin up backend early

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import SplitPane from 'react-split-pane'
 // import AceEditor from 'react-ace';
 import Header from './components/Header'
 import OutputPanel from './components/OutputPanel'
+import { pingBackend } from './services/backendPing'
 import { executeCode } from './services/codeExecution'
 import {
   NotificationContainer,
@@ -105,6 +106,7 @@ class App extends React.Component {
       output: '',
       isRunning: false
     }
+    pingBackend() // Spin up the backend ahead of time
   }
 
   componentDidUpdate (_, prevState) {

--- a/src/services/backendPing.js
+++ b/src/services/backendPing.js
@@ -1,0 +1,15 @@
+import axois from 'axios'
+
+const BACKEND_BASE_URL = 'https://code-craft-grso.onrender.com'
+
+const pingBackend = async () => {
+  try {
+    const response = await axois.get(BACKEND_BASE_URL)
+    return response.status === 200
+  } catch (error) {
+    console.log(`ERROR: ${error}`)
+    return false
+  }
+}
+
+export { pingBackend }


### PR DESCRIPTION
Currently in the backend side, the host service will put the process to sleep after a certain amount of time without traffic. So on the first code run, if the backend is sleeping, it will take a long time since the backend needs to be waken up.

To solve this, we are sending a request to the backend on the app startup to wake it up beforehand.